### PR TITLE
docs: refine readme for accessibility guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,113 @@
-# dimo-validation-app
+# DIMO Validation App
+
+The DIMO Validation App powers the DIMO Data Accuracy tool. Drivers review the
+telemetry coming from their vehicles, report issues, and share updates with the
+DIMO team. The repository contains both the Next.js front end and the
+Firefly-based API that collects each submission.
+
+## Quick links
+- **Production app:** [dimovalidation.com](https://dimovalidation.com)
+- **Support checklist:** [`TODO`](TODO)
+
+## For users
+### Getting started
+1. Visit [dimovalidation.com](https://dimovalidation.com) and activate
+   **Get Started**.
+2. Sign in with your DIMO account. The app may ask you to share specific
+   vehicles before you can edit their data. Permissions that you grant in DIMO
+   Login remain in effect inside the validation experience.
+3. After signing in you land on the dashboard. Shared vehicles appear under
+   **Shared Vehicles**. Unshared vehicles remain under **Vehicles Not Shared**
+   with a button that lets you grant access without leaving the page.
+
+### Keyboard friendly workflow
+- Press `Tab` to move between interactive items and `Shift` + `Tab` to go back.
+- Activate buttons or vehicle tiles with `Enter` or `Space`.
+- Use arrow keys to switch between tabs or list items when the UI offers that
+  control.
+- Every form includes clear focus states so you always know which field is
+  active before typing.
+
+### Validating your data
+- Choose a vehicle tile to review its signals in either the basic or advanced
+  view. You can update values and submit corrections, and the backend will
+  forward your notes to the DIMO team for follow up.
+- If you cannot resolve an issue, open the **Having trouble?** link on the
+  landing page for next steps or support contacts.
+- Submissions do not change data in the mobile app immediately. A disclaimer in
+  the workflow reminds you that the DIMO team confirms each update first.
+
+## For developers
+### Repository layout
+- `app/`: Next.js 14 front end that uses the App Router, Tailwind CSS, and
+  Mapbox components.
+- `backend/`: Express and Firefly TypeScript service that integrates with the
+  DIMO network, Google Sheets, and other data sources.
+- `TODO`: Internal checklist for launch readiness and future enhancements.
+
+### Prerequisites
+- Node.js 20.x and npm 11.x (matches the backend package requirements).
+- Mapbox token and DIMO API credentials for local development.
+- Access to the Google service account and spreadsheet that the backend writes
+  to.
+
+### Environment variables
+Create `.env.local` inside `app/` and `.env` inside `backend/`, or apply your
+preferred secret management approach.
+
+**Front end (`app/.env.local`):**
+- `NEXT_PUBLIC_SERVER_URI`: Base URL for the backend API used by the vehicle
+  hooks and submission flows.
+- `NEXT_PUBLIC_DIMO_CLIENT_ID`: OAuth client used by the DIMO login widget.
+- `NEXT_PUBLIC_DIMO_REDIRECT_URI`: Redirect URI configured for DIMO login
+  flows.
+- `NEXT_PUBLIC_DISCORD_WEBHOOK`: Optional webhook that surfaces runtime errors
+  in your support channels.
+- `NEXT_PUBLIC_MAPBOX_TOKEN`: Public token used by the Mapbox map selector
+  components.
+
+**Backend (`backend/.env`):**
+- `DIMO_CLIENT_ID`, `DIMO_REDIRECT_URI`, `DIMO_CLIENT_KEY`: Credentials for
+  authenticating with the DIMO data APIs and checking vehicle permissions.
+- `GOOGLE_SERVICE_ACCOUNT_EMAIL`, `GOOGLE_SERVICE_ACCOUNT_KEY`,
+  `GOOGLE_SHEET_ID`: Service account values used to append rows to the DIMO
+  validation spreadsheet.
+
+### Installing dependencies
+```bash
+# From the repository root
+cd app && npm install
+cd ../backend && npm install
+```
+
+### Running locally
+1. Start the backend API:
+   ```bash
+   cd backend
+   npm run dev
+   ```
+   Firefly compiles the TypeScript sources and exposes the Express app on the
+   port reported in your terminal. Leave this process running so the front end
+   can proxy API requests.
+2. In a new terminal start the Next.js client:
+   ```bash
+   cd app
+   npm run dev
+   ```
+   Next.js serves the UI at [http://localhost:3000](http://localhost:3000) by
+   default. Update `.env.local` so `NEXT_PUBLIC_SERVER_URI` points to the
+   backend development URL.
+
+### Production build tips
+- `npm run build` and `npm run start` inside `app/` generate the static
+  production build for the Next.js site.
+- `npm run build` inside `backend/` transpiles the Firefly project and produces
+  the `dist/` output that `npm run start` serves.
+- Track launch readiness, support planning, and future enhancements in the
+  [`TODO`](TODO) file so product and support teams stay aligned.
+
+---
+
+Whether you are validating vehicle data or extending the platform, this
+repository provides everything you need to collaborate on the DIMO Validation
+experience.


### PR DESCRIPTION
## Summary
- rewrite the README introduction to use plain ASCII text without long dashes
- add a keyboard-friendly workflow section for users navigating the validation app
- clarify developer environment variables and section formatting for easier scanning

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_6902ac86b7d88320952443a30d236d18